### PR TITLE
breaking: Refactor watcher to use event emitter

### DIFF
--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "node:events";
+
 export enum TypeTag {
   LONG = "long",
   FLOAT = "float",
@@ -62,6 +64,6 @@ export interface Connection {
 }
 
 export interface PreferenceWatch {
-  stream: NodeJS.ReadableStream;
+  emitter: EventEmitter;
   close: () => void;
 }


### PR DESCRIPTION
# Pref Editor - Pull Request

## Description

Use _Node.js_ **EventEmitter** for watch preference functionality.

## Type of Change

<!-- Mark the relevant option with an "x" -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 💥 Breaking change (fix or feature that would cause existing functionality not to work as expected)
-   [ ] 📚 Documentation update
-   [ ] 🔧 Refactoring (no functional changes)
-   [ ] ⚡ Performance improvement
-   [ ] 🧪 Test coverage improvement
-   [ ] 🔨 Build/CI changes
